### PR TITLE
test(federation): subset of tests

### DIFF
--- a/api_basic/api.bats
+++ b/api_basic/api.bats
@@ -31,7 +31,7 @@ setup_file() {
 # bats test_tags=post,pre
 @test "Should be able to see user list" {
 	get users.list
-	assert_field_equal total 2
+	assert_field_equal total 2 # TODO help more on repeatable tests
 }
 
 # bats test_tags=post,pre

--- a/common.bash
+++ b/common.bash
@@ -4,10 +4,11 @@ load "../bats-assert/load.bash"
 load "../bats-support/load.bash"
 load "../bats-file/load.bash"
 
+export readonly ROCKETCHAT_HOST=${ROCKETCHAT_HOST:-"bats.rocket.chat"}
 readonly HOST="${ROCKETCHAT_URL:-http://localhost:3000}"
-readonly EMAIL="dummy@nonexistent.email"
-readonly REALNAME="Dummy User"
-readonly USERNAME="dummy.user"
+readonly EMAIL="dummy+$(date +%s)@nonexistent.email"
+readonly REALNAME="Dummy User $(date +%s)"
+readonly USERNAME="dummy.user.$(date +%s)"
 readonly PASSWORD="dummypassword1234"
 
 api() {
@@ -100,6 +101,8 @@ get() {
 		"x-user-id: $USER_ID"
 		-H
 		"content-type: application/json"
+		-H
+		"Host: $ROCKETCHAT_HOST"
 	)
 	local endpoint
 	endpoint="$(api "${1?endpoint required}")"
@@ -124,6 +127,8 @@ post() {
 		"x-user-id: $USER_ID"
 		-H
 		"content-type: application/json"
+		-H
+		"Host: $ROCKETCHAT_HOST"
 	)
 	local endpoint
 	endpoint="$(api "${1?endpoint required}")"
@@ -142,6 +147,8 @@ post() {
 }
 
 register() {
+	echo "# username=\"$USERNAME\" email=\"$EMAIL\" pass=\"$PASSWORD\" name=\"$REALNAME\"" >&3
+
 	post users.register username="$USERNAME" email="$EMAIL" pass="$PASSWORD" name="$REALNAME"
 }
 

--- a/k8s/microservices.bats
+++ b/k8s/microservices.bats
@@ -12,7 +12,7 @@ export DETIK_CLIENT_NAMESPACE="helm-bats-microservices"
 
 setup_file() {
 	export DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-helm-bats}"
-	export ROCKETCHAT_HOST="${ROCKETCHAT_HOST:-bats.rocket.chat}"
+	export ROCKETCHAT_HOST
 	export ROCKETCHAT_TAG
 	export ROCKETCHAT_CHART_DIR
 	export HELM_TAG="${HELM_TAG:-$ROCKETCHAT_TAG}"

--- a/k8s/monolith.bats
+++ b/k8s/monolith.bats
@@ -12,11 +12,13 @@ export DETIK_CLIENT_NAMESPACE="helm-bats-monolith"
 
 setup_file() {
 	export DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-helm-bats}"
-	export ROCKETCHAT_HOST="${ROCKETCHAT_HOST:-bats.rocket.chat}"
+	export ROCKETCHAT_HOST
 	export ROCKETCHAT_TAG
 	export ROCKETCHAT_CHART_DIR
 	export HELM_TAG="${HELM_TAG:-$ROCKETCHAT_TAG}"
 	export ROCKETCHAT_CHART_ARCHIVE="${ROCKETCHAT_CHART_DIR%/}/rocketchat-${HELM_TAG}.tgz"
+
+	export BATS_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/batsXXXXXXXXX")"
 }
 
 # bats test_tags=pre
@@ -40,7 +42,9 @@ setup_file() {
 			--set 'mongodb.auth.rootPassword=root' \
 			--set 'mongodb.auth.passwords={rocketchat}' \
 			--set 'mongodb.auth.usernames={rocketchat}' \
-			--set 'mongodb.auth.databases={rocketchat}' | kubectl apply --dry-run=client -f -
+			--set 'mongodb.auth.databases={rocketchat}' \
+			--set 'federation.enabled=true' \
+			--set 'ingress.federation.serveWellKnown=true' | kubectl apply --dry-run=client -f -
 	"
 }
 
@@ -65,7 +69,29 @@ setup_file() {
 		--set "prometheusScraping.enabled=true" \
 		--set "prometheusScraping.port=9148" \
 		--set "host=$ROCKETCHAT_HOST" \
+		--set "federation.enabled=true" \
 		--repo https://rocketchat.github.io/helm-charts
+}
+
+# bats test_tags=post
+@test "verify federation secrets are non empty" {
+	#mostly to save the values
+	local \
+		as_token hs_token appservice_id
+
+	as_token="$(\kubectl -n $DETIK_CLIENT_NAMESPACE get secret "$DEPLOYMENT_NAME"-rocketchat-synapse --template='{{.data.as_token}}')" # intentionally kept encoded
+	hs_token="$(\kubectl -n $DETIK_CLIENT_NAMESPACE get secret "$DEPLOYMENT_NAME"-rocketchat-synapse --template='{{.data.hs_token}}')"
+	appservice_id="$(\kubectl -n $DETIK_CLIENT_NAMESPACE get secret "$DEPLOYMENT_NAME"-rocketchat-synapse --template='{{.data.appservice_id}}')"
+
+	refute [ "$as_token" = "" ]
+	refute [ "$hs_token" = "" ]
+	refute [ "$appservice_id" = "" ]
+
+	echo "# saving secret values to recheck later" >&3
+
+	jo as_token="$as_token" hs_token="$hs_token" appservice_id="$appservice_id" > "$BATS_TMPDIR/synapse_secrets.json"
+
+	assert test -f "$BATS_TMPDIR/synapse_secrets.json"
 }
 
 # bats test_tags=post
@@ -80,11 +106,16 @@ setup_file() {
 		--set "prometheusScraping.enabled=true" \
 		--set "prometheusScraping.port=9148" \
 		--set "host=$ROCKETCHAT_HOST" \
+		--set "federation.enabled=true" \
 		"$ROCKETCHAT_CHART_ARCHIVE"
 }
 
 # bats test_tags=pre
 @test "verify the chart actually installs" {
+	if [[ -n $(helm ls -n "$DETIK_CLIENT_NAMESPACE" -l "name=$DEPLOYMENT_NAME" --no-headers -q) ]]; then
+		skip "same release with name already installed"
+	fi
+
 	run_and_assert_success helm install "$DEPLOYMENT_NAME" --namespace "$DETIK_CLIENT_NAMESPACE" --create-namespace \
 		--set "image.tag=$ROCKETCHAT_TAG" \
 		--set "mongodb.auth.rootPassword=root" \
@@ -94,25 +125,30 @@ setup_file() {
 		--set "ingress.enabled=true" \
 		--set "prometheusScraping.enabled=true" \
 		--set "prometheusScraping.port=9148" \
+		--set "federation.enabled=true" \
 		--set "host=$ROCKETCHAT_HOST" \
 		"$ROCKETCHAT_CHART_ARCHIVE"
 }
 
 # bats test_tags=pre,post
 @test "verify all services are up" {
-	run_and_assert_success verify "there is 1 service named '${DEPLOYMENT_NAME}-mongodb-headless'"
-	run_and_assert_success verify "there is 1 service named '${DEPLOYMENT_NAME}-rocketchat'"
+	run_and_assert_success verify "there is 1 service named '${DEPLOYMENT_NAME}-mongodb-headless$'"
+	run_and_assert_success verify "there is 1 service named '${DEPLOYMENT_NAME}-rocketchat$'"
+	run_and_assert_success verify "there is 1 service named '${DEPLOYMENT_NAME}-rocketchat-bridge'"
+	run_and_assert_success verify "there is 1 service named '${DEPLOYMENT_NAME}-rocketchat-synapse'"
 }
 
 # bats test_tags=pre,post
 @test "verify all deployments are up" {
-	run_and_assert_success verify "there is 1 deployment named '${DEPLOYMENT_NAME}-rocketchat'"
+	run_and_assert_success verify "there is 1 deployment named '${DEPLOYMENT_NAME}-rocketchat$'"
+	run_and_assert_success verify "there is 1 deployment named '${DEPLOYMENT_NAME}-rocketchat-synapse'"
 }
 
 # bats test_tags=pre,post
 @test "verify all individual pods exist" {
 	run_and_assert_success try "at most 5 times every 30s to find 1 pod named '${DEPLOYMENT_NAME}-mongodb-0' with 'status' being 'running'"
-	run_and_assert_success try "at most 5 times every 30s to find 1 pod named '^${DEPLOYMENT_NAME}-rocketchat-' with 'status' being 'running'"
+	run_and_assert_success try "at most 5 times every 30s to find 2 pods named '^${DEPLOYMENT_NAME}-rocketchat-' with 'status' being 'running'"
+	run_and_assert_success try "at most 5 times every 30s to find 1 pods named '^${DEPLOYMENT_NAME}-rocketchat-synapse-' with 'status' being 'running'"
 }
 
 # bats test_tags=pre,post
@@ -128,23 +164,31 @@ setup_file() {
 	run_and_assert_success try at most 5 times every 30s \
 		to find 1 ep named "'${DEPLOYMENT_NAME}-rocketchat'" \
 		with "'subsets[*].ports[*].port'" matching "'9148,3000|3000,9148'"
+
+	try at most 5 times every 30s \
+		to find 1 ep named "'${DEPLOYMENT_NAME}-rocketchat-bridge'" \
+		with "'subsets[*].ports[*].port'" being "'3300'"
+
+	try at most 5 times every 30s \
+		to find 1 ep named "'${DEPLOYMENT_NAME}-rocketchat-synapse'" \
+		with "'subsets[*].ports[*].port'" being "'8008'"
 }
 
 # bats test_tags=pre,post
 @test "verify ingress config" {
-	run_and_assert_success verify "'.spec.rules[0].host'" is "'$ROCKETCHAT_HOST'" \
+	verify "'.spec.rules[0].host'" is "'$ROCKETCHAT_HOST'" \
 		for ingress named "'${DEPLOYMENT_NAME}-rocketchat'"
 
-	run_and_assert_success verify "'.spec.rules[*].http.paths[*].backend.service.name'" is "'${DEPLOYMENT_NAME}-rocketchat'" \
+	verify "'.spec.rules[*].http.paths[*].backend.service.name'" is "'${DEPLOYMENT_NAME}-rocketchat,${DEPLOYMENT_NAME}-rocketchat-synapse'" \
 		for ingress named "'${DEPLOYMENT_NAME}-rocketchat'"
 
-	run_and_assert_success verify "'.spec.rules[*].http.paths[*].backend.service.port.name'" is "'http'" \
+	verify "'.spec.rules[*].http.paths[*].backend.service.port.name'" is "'http,http'" \
 		for ingress named "'${DEPLOYMENT_NAME}-rocketchat'"
 
-	run_and_assert_success verify "'.spec.rules[*].http.paths[*].path'" is "'/'" \
+	verify "'.spec.rules[*].http.paths[*].path'" is "'/,/'" \
 		for ingress named "'${DEPLOYMENT_NAME}-rocketchat'"
 
-	run_and_assert_success verify "'.spec.rules[*].http.paths[*].pathType'" is "'Prefix'" \
+	run_and_assert_success verify "'.spec.rules[*].http.paths[*].pathType'" is "'Prefix,Prefix'" \
 		for ingress named "'${DEPLOYMENT_NAME}-rocketchat'"
 }
 
@@ -156,19 +200,41 @@ setup_file() {
 	local \
 		root_password="$(printf "root" | base64)" \
 		password="$(printf "rocketchat" | base64)"
+
 	debug "password=$password"
-	run_and_assert_success verify "'.data.mongodb-passwords'" matches "'^$password\$'" \
+
+	verify "'.data.mongodb-passwords'" matches "'^$password\$'" \
 		for secret named "'${DEPLOYMENT_NAME}-mongodb'"
-	run_and_assert_success verify "'.data.mongodb-root-password'" matches "'^$root_password\$'" \
+	verify "'.data.mongodb-root-password'" matches "'^$root_password\$'" \
 		for secret named "'${DEPLOYMENT_NAME}-mongodb'"
 
 	local \
 		mongo_uri="$(printf "mongodb://rocketchat:rocketchat@%s-mongodb-headless:27017/rocketchat?replicaSet=rs0" "$DEPLOYMENT_NAME" | base64)" \
 		mongo_oplog_uri="$(printf "mongodb://root:root@%s-mongodb-headless:27017/local?replicaSet=rs0&authSource=admin" "$DEPLOYMENT_NAME" | base64)"
-	run_and_assert_success verify "'.data.mongo-uri'" matches "'^$mongo_uri\$'" \
-		for secret named "'${DEPLOYMENT_NAME}-rocketchat'"
-	run_and_assert_success verify "'.data.mongo-oplog-uri'" matches "'^$mongo_oplog_uri\$'" \
-		for secret named "'${DEPLOYMENT_NAME}-rocketchat'"
+	verify "'.data.mongo-uri'" matches "'^$mongo_uri\$'" \
+		for secret named "'${DEPLOYMENT_NAME}-rocketchat[^-]'"
+	verify "'.data.mongo-oplog-uri'" matches "'^$mongo_oplog_uri\$'" \
+		for secret named "'${DEPLOYMENT_NAME}-rocketchat[^-]'"
+}
+
+# bats test_tags=post
+@test "verify federation secrets are unchanged post-upgrade/reapply" {
+	# federation secret
+	local \
+		as_token hs_token appservice_id
+
+	assert test -f  "$BATS_TMPDIR/synapse_secrets.json"
+
+	as_token="$(jq -r .as_token "$BATS_TMPDIR/synapse_secrets.json")"
+	hs_token="$(jq -r .hs_token "$BATS_TMPDIR/synapse_secrets.json")"
+	appservice_id="$(jq -r .appservice_id "$BATS_TMPDIR/synapse_secrets.json")"
+
+	verify "'.data.as_token'" matches "'^$as_token\$'" \
+		for secret named "'${DEPLOYMENT_NAME}-rocketchat-synapse'"
+	verify "'.data.hs_token'" matches "'^$hs_token\$'" \
+		for secret named "'${DEPLOYMENT_NAME}-rocketchat-synapse'"
+	verify "'.data.appservice_id'" matches "'^$appservice_id\$'" \
+		for secret named "'${DEPLOYMENT_NAME}-rocketchat-synapse'"
 }
 
 # bats test_tags=pre,post
@@ -181,4 +247,8 @@ setup_file() {
 @test "verify uninstalling rocketchat chart" {
 	run_and_assert_success helm uninstall "$DEPLOYMENT_NAME" -n "$DETIK_CLIENT_NAMESPACE"
 	run_and_assert_success kubectl delete namespace "$DETIK_CLIENT_NAMESPACE"
+}
+
+teardown_file() {
+	rm -rf $BATS_TMPDIR
 }

--- a/run_k8s.bash
+++ b/run_k8s.bash
@@ -34,8 +34,6 @@ run_test() {
 
 	echo "${ascii_arts[$type]}"
 
-	bats pre k8s/$type.bats
-
 	declare -g ip=
 	if ! ip="$(
 		\kubectl -n kube-system get svc traefik \
@@ -46,6 +44,9 @@ run_test() {
 	fi
 
 	export ROCKETCHAT_URL="http://$ip"
+
+	bats pre k8s/$type.bats
+
 	bats 'pre,post' ./api_basic/api.bats
 	bats post k8s/$type.bats
 }


### PR DESCRIPTION
Only add tests for the new default, when rocket.chat handles the wellknown responses.

As long as the secrets stay the same, ingress records exist for others to talk, rocketchat is pointing to the right url, theoretically everything should work. 

I hope am not forgetting anything.